### PR TITLE
Import/Export Functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,13 @@ function App() {
   } else if (showWorkspace) {
     return (
       <div className="app">
-        <Workspace height={height as number} width={width as number} handleResetParent={handleReset}/>
+        <Workspace
+          height={height as number}
+          width={width as number}
+          setWidth={setWidth}
+          setHeight={setHeight}
+          handleResetParent={handleReset}
+        />
       </div>
     )
   } else {

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -122,7 +122,7 @@ export default function Workspace(props: WorkspaceProps) {
     // setting prototype is not recursive, must be set manually
     fileObject.text().then((layoutJson: any) => {
       const layoutObject = JSON.parse(layoutJson);
-      Object.setPrototypeOf(layoutObject, Layout);
+      Object.setPrototypeOf(layoutObject, Layout.prototype);
       for (const row of layoutObject.layout) {
         for (const layoutComponent of row) {
           // only wall types have a className on them

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -161,8 +161,6 @@ export default function Workspace(props: WorkspaceProps) {
     <PlanGrid
       height={props.height}
       width={props.width}
-      setHeight={props.setHeight}
-      setWidth={props.setWidth}
       layout={layout}
       setLayoutParent={setLayout}
       draggedMenuItem={draggedItem}

--- a/src/Workspace.tsx
+++ b/src/Workspace.tsx
@@ -12,6 +12,8 @@ import "./Workspace.css";
 export interface WorkspaceProps {
   height: number;
   width: number;
+  setWidth: (width: number) => void;
+  setHeight: (height: number) => void;
   handleResetParent: () => void;
 }
 
@@ -106,6 +108,8 @@ export default function Workspace(props: WorkspaceProps) {
     <PlanGrid
       height={props.height}
       width={props.width}
+      setHeight={props.setHeight}
+      setWidth={props.setWidth}
       layout={layout}
       setLayoutParent={setLayout}
       draggedMenuItem={draggedItem}

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -200,8 +200,6 @@ export function DrawGrid(props: DrawGridProps) {
 interface PlanGridProps {
   height: number;
   width: number;
-  setHeight: (height: number) => void;
-  setWidth: (width: number) => void;
   layout: Layout;
   setLayoutParent: (layout: Layout) => void;
   draggedMenuItem: SquareType | undefined;

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -389,12 +389,12 @@ export function PlanGrid(props: PlanGridProps) {
       Object.setPrototypeOf(layoutObject, Layout);
       for (let i = 0; i < layoutObject.layout.length; i++) {
         for (let j = 0; j < layoutObject.layout[i].length; j++) {
-          const el = layoutObject.layout[i][j];
+          const layoutComponent = layoutObject.layout[i][j];
 
           // only wall types have a className on them
-          const objectType = !!el?.className ? WallType : SquareType;
-          Object.setPrototypeOf(el, objectType.prototype);
-          layoutObject.layout[i][j] = el;
+          const objectType = !!layoutComponent?.className ? WallType : SquareType;
+          Object.setPrototypeOf(layoutComponent, objectType.prototype);
+          layoutObject.layout[i][j] = layoutComponent;
         }
       }
 
@@ -613,7 +613,7 @@ export function PlanGrid(props: PlanGridProps) {
               false,
               false
             )}
-            <input ref={fileUploadRef} onClick={handleLayoutUpload} id='fileid' type='file' hidden/>
+            <input ref={fileUploadRef} onChange={handleLayoutUpload} id='fileid' type='file' hidden/>
           </>
         </div>
       </div>

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, MouseEvent, SyntheticEvent, DragEvent } from "react";
+import { useState, useEffect, MouseEvent, SyntheticEvent, DragEvent, useRef } from "react";
 import {
   RotateLeftOutlined,
   RotateRightOutlined,
   DeleteOutlined,
   SaveOutlined,
+  CloudUploadOutlined,
 } from "@ant-design/icons";
 
 import { WallType, SquareType, styledButton } from "./helpers";
@@ -212,6 +213,7 @@ interface PlanGridProps {
 }
 
 export function PlanGrid(props: PlanGridProps) {
+  const fileUploadRef = useRef<HTMLInputElement>(null);
   const [hoveredCell, setHoveredCell] = useState<[number, number] | undefined>(
     undefined
   );
@@ -365,6 +367,14 @@ export function PlanGrid(props: PlanGridProps) {
     link.click();
     document.body.removeChild(link);
   };
+
+  const handleImportLayout = () => {
+    if (!fileUploadRef.current) {
+      return;
+    }
+
+    fileUploadRef.current.click();
+  }
 
   useEffect(() => {
     window.onkeydown = (event: KeyboardEvent) => {
@@ -566,6 +576,14 @@ export function PlanGrid(props: PlanGridProps) {
               false,
               false
             )}
+            {styledButton(
+              "Import layout",
+              handleImportLayout,
+              <CloudUploadOutlined />,
+              false,
+              false
+            )}
+            <input ref={fileUploadRef} id='fileid' type='file' hidden/>
           </>
         </div>
       </div>

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -354,6 +354,16 @@ export function PlanGrid(props: PlanGridProps) {
 
   const handleExportLayout = () => {
     const layoutString = JSON.stringify(props.layout);
+    const encodingMetadata = 'data:text/json;charset=utf-8';
+    const layoutURI = encodeURI(`${encodingMetadata},${layoutString}`);
+
+    const link = document.createElement('a');
+    link.setAttribute('href', layoutURI);
+    link.setAttribute('download', 'layout.json');
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   useEffect(() => {

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -1,10 +1,8 @@
-import { useState, useEffect, MouseEvent, SyntheticEvent, DragEvent, useRef } from "react";
+import { useState, useEffect, MouseEvent, SyntheticEvent, DragEvent } from "react";
 import {
   RotateLeftOutlined,
   RotateRightOutlined,
   DeleteOutlined,
-  SaveOutlined,
-  CloudUploadOutlined,
 } from "@ant-design/icons";
 
 import { WallType, SquareType, styledButton } from "./helpers";
@@ -215,7 +213,6 @@ interface PlanGridProps {
 }
 
 export function PlanGrid(props: PlanGridProps) {
-  const fileUploadRef = useRef<HTMLInputElement>(null);
   const [hoveredCell, setHoveredCell] = useState<[number, number] | undefined>(
     undefined
   );
@@ -355,58 +352,6 @@ export function PlanGrid(props: PlanGridProps) {
     newLayout.removeSquares();
     props.setLayoutParent(newLayout);
   };
-
-  // downloads the Layout object properties as a JSON file
-  const handleExportLayout = () => {
-    const layoutString = JSON.stringify(props.layout);
-    const encodingMetadata = 'data:text/json;charset=utf-8';
-    const layoutURI = encodeURI(`${encodingMetadata},${layoutString}`);
-
-    const link = document.createElement('a');
-    link.setAttribute('href', layoutURI);
-    link.setAttribute('download', 'layout.json');
-
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
-  const handleImportLayout = () => {
-    if (!fileUploadRef.current) {
-      return;
-    }
-
-    fileUploadRef.current.click();
-  }
-
-  // converts a JSON file to a Layout object if possible
-  const handleLayoutUpload = (event: any) => {
-    const fileObject = event.target.files && event.target.files[0];
-    if (!fileObject) {
-      return;
-    }
-
-    // setting prototype is not recursive, must be set manually
-    fileObject.text().then((layoutJson: any) => {
-      const layoutObject = JSON.parse(layoutJson);
-      Object.setPrototypeOf(layoutObject, Layout);
-      for (const row of layoutObject.layout) {
-        for (const layoutComponent of row) {
-          // only wall types have a className on them
-          const objectType = !!layoutComponent?.className ? WallType : SquareType;
-          Object.setPrototypeOf(layoutComponent, objectType.prototype);
-        }
-      }
-
-      for (const element of layoutObject.elements) {
-        Object.setPrototypeOf(element, SquareType.prototype);
-      }
-
-      props.setWidth(layoutObject.width);
-      props.setHeight(layoutObject.height);
-      props.setLayoutParent(layoutObject);
-    })
-  }
 
   useEffect(() => {
     window.onkeydown = (event: KeyboardEvent) => {
@@ -601,21 +546,6 @@ export function PlanGrid(props: PlanGridProps) {
               false,
               props.layout.elements.length <= 0
             )}
-            {styledButton(
-              "Export layout",
-              handleExportLayout,
-              <SaveOutlined />,
-              false,
-              false
-            )}
-            {styledButton(
-              "Import layout",
-              handleImportLayout,
-              <CloudUploadOutlined />,
-              false,
-              false
-            )}
-            <input ref={fileUploadRef} onChange={handleLayoutUpload} id='fileid' type='file' hidden/>
           </>
         </div>
       </div>

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -356,6 +356,7 @@ export function PlanGrid(props: PlanGridProps) {
     props.setLayoutParent(newLayout);
   };
 
+  // downloads the Layout object properties as a JSON file
   const handleExportLayout = () => {
     const layoutString = JSON.stringify(props.layout);
     const encodingMetadata = 'data:text/json;charset=utf-8';
@@ -378,30 +379,27 @@ export function PlanGrid(props: PlanGridProps) {
     fileUploadRef.current.click();
   }
 
+  // converts a JSON file to a Layout object if possible
   const handleLayoutUpload = (event: any) => {
     const fileObject = event.target.files && event.target.files[0];
     if (!fileObject) {
       return;
     }
 
-    // Convert JSON string to objects using prototype hacks
-    // is not recursive therefore fields must be set manually
+    // setting prototype is not recursive, must be set manually
     fileObject.text().then((layoutJson: any) => {
       const layoutObject = JSON.parse(layoutJson);
       Object.setPrototypeOf(layoutObject, Layout);
-      for (let i = 0; i < layoutObject.layout.length; i++) {
-        for (let j = 0; j < layoutObject.layout[i].length; j++) {
-          const layoutComponent = layoutObject.layout[i][j];
-
+      for (const row of layoutObject.layout) {
+        for (const layoutComponent of row) {
           // only wall types have a className on them
           const objectType = !!layoutComponent?.className ? WallType : SquareType;
           Object.setPrototypeOf(layoutComponent, objectType.prototype);
-          layoutObject.layout[i][j] = layoutComponent;
         }
       }
 
-      for (let i = 0; i < layoutObject.elements.length; i++) {
-        Object.setPrototypeOf(layoutObject.elements[i], SquareType.prototype);
+      for (const element of layoutObject.elements) {
+        Object.setPrototypeOf(element, SquareType.prototype);
       }
 
       props.setWidth(layoutObject.width);

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -202,6 +202,8 @@ export function DrawGrid(props: DrawGridProps) {
 interface PlanGridProps {
   height: number;
   width: number;
+  setHeight: (height: number) => void;
+  setWidth: (width: number) => void;
   layout: Layout;
   setLayoutParent: (layout: Layout) => void;
   draggedMenuItem: SquareType | undefined;
@@ -402,6 +404,8 @@ export function PlanGrid(props: PlanGridProps) {
         Object.setPrototypeOf(layoutObject.elements[i], SquareType.prototype);
       }
 
+      props.setWidth(layoutObject.width);
+      props.setHeight(layoutObject.height);
       props.setLayoutParent(layoutObject);
     })
   }

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -3,6 +3,7 @@ import {
   RotateLeftOutlined,
   RotateRightOutlined,
   DeleteOutlined,
+  SaveOutlined,
 } from "@ant-design/icons";
 
 import { WallType, SquareType, styledButton } from "./helpers";
@@ -351,6 +352,10 @@ export function PlanGrid(props: PlanGridProps) {
     props.setLayoutParent(newLayout);
   };
 
+  const handleExportLayout = () => {
+    const layoutString = JSON.stringify(props.layout);
+  };
+
   useEffect(() => {
     window.onkeydown = (event: KeyboardEvent) => {
       if (!props.textInputInFocus && (event.key === "Backspace" || event.key === "Delete")) {
@@ -543,6 +548,13 @@ export function PlanGrid(props: PlanGridProps) {
               <DeleteOutlined />,
               false,
               props.layout.elements.length <= 0
+            )}
+            {styledButton(
+              "Export layout",
+              handleExportLayout,
+              <SaveOutlined />,
+              false,
+              false
             )}
           </>
         </div>

--- a/src/grids.tsx
+++ b/src/grids.tsx
@@ -376,6 +376,36 @@ export function PlanGrid(props: PlanGridProps) {
     fileUploadRef.current.click();
   }
 
+  const handleLayoutUpload = (event: any) => {
+    const fileObject = event.target.files && event.target.files[0];
+    if (!fileObject) {
+      return;
+    }
+
+    // Convert JSON string to objects using prototype hacks
+    // is not recursive therefore fields must be set manually
+    fileObject.text().then((layoutJson: any) => {
+      const layoutObject = JSON.parse(layoutJson);
+      Object.setPrototypeOf(layoutObject, Layout);
+      for (let i = 0; i < layoutObject.layout.length; i++) {
+        for (let j = 0; j < layoutObject.layout[i].length; j++) {
+          const el = layoutObject.layout[i][j];
+
+          // only wall types have a className on them
+          const objectType = !!el?.className ? WallType : SquareType;
+          Object.setPrototypeOf(el, objectType.prototype);
+          layoutObject.layout[i][j] = el;
+        }
+      }
+
+      for (let i = 0; i < layoutObject.elements.length; i++) {
+        Object.setPrototypeOf(layoutObject.elements[i], SquareType.prototype);
+      }
+
+      props.setLayoutParent(layoutObject);
+    })
+  }
+
   useEffect(() => {
     window.onkeydown = (event: KeyboardEvent) => {
       if (!props.textInputInFocus && (event.key === "Backspace" || event.key === "Delete")) {
@@ -583,7 +613,7 @@ export function PlanGrid(props: PlanGridProps) {
               false,
               false
             )}
-            <input ref={fileUploadRef} id='fileid' type='file' hidden/>
+            <input ref={fileUploadRef} onClick={handleLayoutUpload} id='fileid' type='file' hidden/>
           </>
         </div>
       </div>


### PR DESCRIPTION
- Added buttons to import and export layouts.
- Currently does nothing on a bad upload (e.g. if I upload a PDF or some invalid JSON).
- Export saves the current layout as JSON.
- Import loads JSON generated by the export button, changing the dimensions and the layout accordingly.

Example of me using both the export and import features:
[plateup_import_export.webm](https://user-images.githubusercontent.com/66381057/193865377-b02df74f-4f7a-47d9-bf4f-f6420b9ecbde.webm)
