### PR TITLE
Duplicate selected Square

### DIFF
--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -5,6 +5,7 @@ import {
   IconRotateClockwise2,
   IconTrash,
   IconTrashX,
+  IconCopy,
 } from '@tabler/icons';
 import { useState, SyntheticEvent, MouseEvent, DragEvent } from 'react';
 import shallow from 'zustand/shallow';
@@ -249,6 +250,14 @@ const PlanGrid = () => {
     }
   };
 
+  const handleDuplicateSelected = () => {
+    if (selectedCell === undefined) return;
+
+    const newLayout = layout.clone();
+    newLayout.duplicateElement(selectedCell, hoveredCell);
+    setLayout(newLayout);
+  };
+
   useHotkeys([
     ['Backspace', () => handleDelete()],
     ['Delete', () => handleDelete()],
@@ -262,6 +271,7 @@ const PlanGrid = () => {
     ['ArrowLeft', () => handleSelectionMove(-1, 0)],
     ['ArrowDown', () => handleSelectionMove(0, 1)],
     ['ArrowRight', () => handleSelectionMove(1, 0)],
+    ['CTRL+D', () => handleDuplicateSelected()],
   ]);
 
   const getPlanGridElements = () => {
@@ -408,6 +418,14 @@ const PlanGrid = () => {
           disabled={selectedCell === undefined}
         >
           <IconRotate2 stroke='2.5' size={20} />
+        </ActionIcon>
+        <ActionIcon
+          onClick={() => handleDuplicateSelected()}
+          size='xl'
+          radius='xl'
+          disabled={selectedCell === undefined}
+        >
+          <IconCopy stroke='2.5' size={20} />
         </ActionIcon>
         <ActionIcon
           onClick={() => handleDelete()}

--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -420,6 +420,14 @@ const PlanGrid = () => {
           <IconRotate2 stroke='2.5' size={20} />
         </ActionIcon>
         <ActionIcon
+          onClick={() => handleRotateRight()}
+          size='xl'
+          radius='xl'
+          disabled={selectedCell === undefined}
+        >
+          <IconRotateClockwise2 stroke='2.5' size={20} />
+        </ActionIcon>
+        <ActionIcon
           onClick={() => handleDuplicateSelected()}
           size='xl'
           radius='xl'
@@ -434,14 +442,6 @@ const PlanGrid = () => {
           disabled={selectedCell === undefined}
         >
           <IconTrashX stroke='2.5' size={20} />
-        </ActionIcon>
-        <ActionIcon
-          onClick={() => handleRotateRight()}
-          size='xl'
-          radius='xl'
-          disabled={selectedCell === undefined}
-        >
-          <IconRotateClockwise2 stroke='2.5' size={20} />
         </ActionIcon>
         <Button
           onClick={() => handleRemoveSquares()}

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -136,6 +136,34 @@ export class Layout {
     }
     this.elements = [];
   }
+
+  duplicateElement(
+    selectedCell: [number, number],
+    hoveredCell: [number, number] | undefined,
+  ) {
+    const selectedCellX = selectedCell[0];
+    const selectedCellY = selectedCell[1];
+
+    if (!(this.layout[selectedCellX][selectedCellY] instanceof SquareType)) {
+      throw new Error('Cannot rotate a wall element');
+    }
+
+    const square = this.layout[selectedCellX][selectedCellY] as SquareType;
+
+    if (hoveredCell) {
+      this.setElement(hoveredCell[0], hoveredCell[1], square);
+    } else {
+      // If hoveredCell is undefined, duplicate to first Empty Square
+      for (let i = 0; i < this.height * 2 - 1; i++) {
+        for (let j = 0; j < this.width * 2 - 1; j++) {
+          if (this.layout[i][j] == SquareType.Empty) {
+            this.setElement(i, j, square);
+            return;
+          }
+        }
+      }
+    }
+  }
 }
 
 export function encodeLayoutString(layout: Layout) {

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -151,7 +151,7 @@ export class Layout {
     const square = this.layout[selectedCellX][selectedCellY] as SquareType;
 
     if (hoveredCell) {
-      this.setElement(hoveredCell[0], hoveredCell[1], square);
+      this.setElement(hoveredCell[0], hoveredCell[1], square.clone());
     } else {
       // If hoveredCell is undefined, duplicate to first Empty Square
       for (let i = 0; i < this.height * 2 - 1; i++) {

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -144,14 +144,13 @@ export class Layout {
     selectedCell: [number, number],
     hoveredCell: [number, number] | undefined,
   ) {
-    const selectedCellY = selectedCell[0];
-    const selectedCellX = selectedCell[1];
-
-    if (!(this.layout[selectedCellY][selectedCellX] instanceof SquareType)) {
-      throw new Error('Cannot rotate a wall element');
+    if (
+      !(this.layout[selectedCell[0]][selectedCell[1]] instanceof SquareType)
+    ) {
+      throw new Error('Cannot duplicate a wall element');
     }
 
-    const square = this.layout[selectedCellY][selectedCellX] as SquareType;
+    const square = this.layout[selectedCell[0]][selectedCell[1]] as SquareType;
 
     if (hoveredCell && this.isEmptySquare(hoveredCell[0], hoveredCell[1])) {
       this.setElement(hoveredCell[0], hoveredCell[1], square.clone());
@@ -167,8 +166,8 @@ export class Layout {
     }
   }
 
-  isEmptySquare(y: number, x: number): boolean {
-    const square = this.layout[y][x] as SquareType;
+  isEmptySquare(i: number, j: number): boolean {
+    const square = this.layout[i][j] as SquareType;
     return square && square === SquareType.Empty;
   }
 }

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -137,6 +137,9 @@ export class Layout {
     this.elements = [];
   }
 
+  // Duplicate element in the selected cell
+  // It will either be placed in the hoveredCell, if it is not a wall and not already occupied
+  // Or it will be placed in the first empty cell
   duplicateElement(
     selectedCell: [number, number],
     hoveredCell: [number, number] | undefined,
@@ -150,19 +153,23 @@ export class Layout {
 
     const square = this.layout[selectedCellX][selectedCellY] as SquareType;
 
-    if (hoveredCell) {
+    if (hoveredCell && this.isEmptySquare(hoveredCell[0], hoveredCell[1])) {
       this.setElement(hoveredCell[0], hoveredCell[1], square.clone());
     } else {
-      // If hoveredCell is undefined, duplicate to first Empty Square
       for (let i = 0; i < this.height * 2 - 1; i++) {
         for (let j = 0; j < this.width * 2 - 1; j++) {
-          if (this.layout[i][j] == SquareType.Empty) {
-            this.setElement(i, j, square);
+          if (this.isEmptySquare(i, j)) {
+            this.setElement(i, j, square.clone());
             return;
           }
         }
       }
     }
+  }
+
+  isEmptySquare(x: number, y: number): boolean {
+    const square = this.layout[x][y] as SquareType;
+    return square && square === SquareType.Empty;
   }
 }
 

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -144,14 +144,14 @@ export class Layout {
     selectedCell: [number, number],
     hoveredCell: [number, number] | undefined,
   ) {
-    const selectedCellX = selectedCell[0];
-    const selectedCellY = selectedCell[1];
+    const selectedCellY = selectedCell[0];
+    const selectedCellX = selectedCell[1];
 
-    if (!(this.layout[selectedCellX][selectedCellY] instanceof SquareType)) {
+    if (!(this.layout[selectedCellY][selectedCellX] instanceof SquareType)) {
       throw new Error('Cannot rotate a wall element');
     }
 
-    const square = this.layout[selectedCellX][selectedCellY] as SquareType;
+    const square = this.layout[selectedCellY][selectedCellX] as SquareType;
 
     if (hoveredCell && this.isEmptySquare(hoveredCell[0], hoveredCell[1])) {
       this.setElement(hoveredCell[0], hoveredCell[1], square.clone());
@@ -167,8 +167,8 @@ export class Layout {
     }
   }
 
-  isEmptySquare(x: number, y: number): boolean {
-    const square = this.layout[x][y] as SquareType;
+  isEmptySquare(y: number, x: number): boolean {
+    const square = this.layout[y][x] as SquareType;
     return square && square === SquareType.Empty;
   }
 }

--- a/src/components/modals/infoModal/InfoModal.tsx
+++ b/src/components/modals/infoModal/InfoModal.tsx
@@ -69,6 +69,10 @@ const InfoModal = ({ className }: Props) => {
               </div>
               <span>rotate selected item left/right</span>
               <div>
+                <kbd>CTRL+D</kbd>
+              </div>
+              <span>duplicate selected item</span>
+              <div>
                 <kbd>?</kbd>
               </div>
               <span>toggle info modal</span>

--- a/src/components/modals/infoModal/InfoModal.tsx
+++ b/src/components/modals/infoModal/InfoModal.tsx
@@ -69,7 +69,7 @@ const InfoModal = ({ className }: Props) => {
               </div>
               <span>rotate selected item left/right</span>
               <div>
-                <kbd>CTRL+D</kbd>
+                <kbd>Ctrl</kbd>+<kbd>D</kbd>
               </div>
               <span>duplicate selected item</span>
               <div>


### PR DESCRIPTION
Created a little feature to allow users to quickly duplicate whatever they have selected to either wherever the user is hovering or the first available empty square.
Hotkey is currently 'ctrl+d'.