### PR TITLE
Feature: Add touch support (complete basic mobile functionality)

### DIFF
--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -1,3 +1,4 @@
+import type { Cell, CellOption } from '../../types/project';
 import { ActionIcon, Button } from '@mantine/core';
 import { useHotkeys } from '@mantine/hooks';
 import {
@@ -11,7 +12,6 @@ import { useState, SyntheticEvent, MouseEvent, DragEvent } from 'react';
 import shallow from 'zustand/shallow';
 import { useLayoutStore } from '../../store/layoutStore';
 import { useWorkspaceStore } from '../../store/workspaceStore';
-import { Cell } from '../../types/project';
 import {
   areSameCell,
   isTouchDevice,
@@ -48,15 +48,9 @@ const PlanGrid = () => {
     shallow,
   );
 
-  const [hoveredCell, setHoveredCell] = useState<[number, number] | undefined>(
-    undefined,
-  );
-  const [clickedCell, setClickedCell] = useState<[number, number] | undefined>(
-    undefined,
-  );
-  const [draggedOverCell, setDraggedOverCell] = useState<
-    [number, number] | undefined
-  >(undefined);
+  const [hoveredCell, setHoveredCell] = useState<CellOption>(undefined);
+  const [clickedCell, setClickedCell] = useState<CellOption>(undefined);
+  const [draggedOverCell, setDraggedOverCell] = useState<CellOption>(undefined);
 
   const getCursorState = () => {
     if (draggedItem !== undefined && draggedPosition !== undefined) {
@@ -210,10 +204,10 @@ const PlanGrid = () => {
     if (selectedCell !== undefined) {
       const [p, q] = selectedCell;
       // BFS to find first non-empty cell in that direction (quarter circle) from selected
-      const queue: [number, number][] = [[dx, dy]];
+      const queue: Cell[] = [[dx, dy]];
       const seen = {} as { [key: string]: boolean };
       while (queue.length > 0) {
-        const [cdx, cdy] = queue.shift() as [number, number];
+        const [cdx, cdy] = queue.shift() as Cell;
         const key = `${cdx},${cdy}`;
         const [i, j] = [p + 2 * cdy, q + 2 * cdx];
         if (

--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -275,7 +275,19 @@ const PlanGrid = () => {
     ['CTRL+D', () => handleDuplicateSelected()],
   ]);
 
-  const handleTouchEnd = (cell: Cell, isItemCell: boolean) => {
+  const handleTouchEnd = (
+    cell: Cell,
+    isItemCell: boolean,
+    event: React.TouchEvent,
+  ) => {
+    // Try to ignore multi-touch guestures (doesn't work well)
+    if (
+      event.touches.length > 1 ||
+      event.targetTouches.length > 1 ||
+      event.changedTouches.length > 1
+    ) {
+      return;
+    }
     // No cell selected so select the tapped one
     if (selectedCell === undefined && isItemCell) {
       setSelectedCell(cell);
@@ -369,7 +381,7 @@ const PlanGrid = () => {
                 }
                 onTouchEnd={(e) => {
                   e.preventDefault();
-                  handleTouchEnd([i, j], true);
+                  handleTouchEnd([i, j], true, e);
                 }}
                 onContextMenu={(e) => e.preventDefault()}
               />
@@ -380,7 +392,7 @@ const PlanGrid = () => {
                 className='grid-image'
                 onTouchEnd={(e) => {
                   e.preventDefault();
-                  handleTouchEnd([i, j], false);
+                  handleTouchEnd([i, j], false, e);
                 }}
               />
             );

--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -143,9 +143,7 @@ const PlanGrid = () => {
       setLayout(newLayout);
     } else if (
       clickedCell !== undefined &&
-      (selectedCell === undefined ||
-        clickedCell[0] !== selectedCell[0] ||
-        clickedCell[1] !== selectedCell[1])
+      (selectedCell === undefined || !areSameCell(clickedCell, selectedCell))
     ) {
       setSelectedCell(clickedCell);
     } else {
@@ -325,26 +323,21 @@ const PlanGrid = () => {
       for (let j = 0; j < width * 2 - 1; j++) {
         if (i % 2 === 0 && j % 2 === 0) {
           let selected = '';
-          if (
-            selectedCell !== undefined &&
-            selectedCell[0] === i &&
-            selectedCell[1] === j
-          ) {
+          if (selectedCell !== undefined && areSameCell(selectedCell, [i, j])) {
             selected = 'grid-selected';
           }
 
           let squareType = layout.layout?.[i]?.[j] as SquareType;
           let opacity = 1;
           if (draggedOverCell !== undefined) {
-            if (draggedOverCell[0] === i && draggedOverCell[1] === j) {
+            if (areSameCell(draggedOverCell, [i, j])) {
               squareType = layout.layout[clickedCell?.[0] ?? 0][
                 clickedCell?.[1] ?? 0
               ] as SquareType;
               opacity = 0.7;
             } else if (
               clickedCell !== undefined &&
-              clickedCell[0] === i &&
-              clickedCell[1] === j
+              areSameCell(clickedCell, [i, j])
             ) {
               squareType = layout.layout[draggedOverCell[0]][
                 draggedOverCell[1]
@@ -356,8 +349,7 @@ const PlanGrid = () => {
           if (
             draggedItem !== undefined &&
             draggedPosition !== undefined &&
-            draggedPosition[0] === i &&
-            draggedPosition[1] === j
+            areSameCell(draggedPosition, [i, j])
           ) {
             squareType = draggedItem;
             opacity = 0.7;

--- a/src/components/grids/PlanGrid.tsx
+++ b/src/components/grids/PlanGrid.tsx
@@ -12,7 +12,12 @@ import shallow from 'zustand/shallow';
 import { useLayoutStore } from '../../store/layoutStore';
 import { useWorkspaceStore } from '../../store/workspaceStore';
 import { Cell } from '../../types/project';
-import { areSameCell, SquareType, WallType } from '../../utils/helpers';
+import {
+  areSameCell,
+  isTouchDevice,
+  SquareType,
+  WallType,
+} from '../../utils/helpers';
 import * as styled from './styled';
 
 const PlanGrid = () => {
@@ -98,7 +103,13 @@ const PlanGrid = () => {
       return `Selected ${selectedCellType.getImageAlt()}`;
     }
 
-    return <i>Left click to select or drag; right click to rotate.</i>;
+    return (
+      <i>
+        {isTouchDevice()
+          ? 'Tap to select; tap again to move or swap.'
+          : 'Left click to select or drag; right click to rotate.'}
+      </i>
+    );
   };
 
   const handleMouseDown = (i: number, j: number, event: MouseEvent) => {

--- a/src/components/layout/Layout.ts
+++ b/src/components/layout/Layout.ts
@@ -1,3 +1,4 @@
+import type { Cell, CellOption } from '../../types/project';
 import LZString from 'lz-string';
 
 import { SquareType, WallType } from '../../utils/helpers';
@@ -140,10 +141,7 @@ export class Layout {
   // Duplicate element in the selected cell
   // It will either be placed in the hoveredCell, if it is not a wall and not already occupied
   // Or it will be placed in the first empty cell
-  duplicateElement(
-    selectedCell: [number, number],
-    hoveredCell: [number, number] | undefined,
-  ) {
+  duplicateElement(selectedCell: Cell, hoveredCell: CellOption) {
     if (
       !(this.layout[selectedCell[0]][selectedCell[1]] instanceof SquareType)
     ) {

--- a/src/components/modals/touchWarningModal/TouchWarningModal.tsx
+++ b/src/components/modals/touchWarningModal/TouchWarningModal.tsx
@@ -17,9 +17,9 @@ const TouchWarning = () => {
     >
       <styled.TouchWarningModal>
         <p>
-          PlateUp! Planner has not been implemented for touchscreen devices yet
-          and will not work unless you have a mouse or keyboard. Continue at
-          your own risk!
+          PlateUp! Planner only has basic functionality for touchscreen devices
+          right now so your experience may not be as good as it would be with a
+          mouse or keyboard. Continue at your own risk!
         </p>
         <Button
           onClick={() => setOpened(false)}

--- a/src/components/modals/touchWarningModal/TouchWarningModal.tsx
+++ b/src/components/modals/touchWarningModal/TouchWarningModal.tsx
@@ -2,12 +2,10 @@ import { useState } from 'react';
 import { Button, Modal } from '@mantine/core';
 import * as styled from './styled';
 import { IconChevronsRight } from '@tabler/icons';
+import { isTouchDevice } from '../../../utils/helpers';
 
 const TouchWarning = () => {
-  const isTouchDevice =
-    'ontouchstart' in window || window.navigator.maxTouchPoints > 0;
-
-  const [opened, setOpened] = useState(isTouchDevice);
+  const [opened, setOpened] = useState(isTouchDevice());
 
   return (
     <Modal

--- a/src/store/layoutStore.ts
+++ b/src/store/layoutStore.ts
@@ -2,7 +2,7 @@ import type { CellOption } from '../types/project';
 import { DependencyList, useEffect, useRef } from 'react';
 import create, { StateCreator } from 'zustand';
 import { Layout } from '../components/layout/Layout';
-import { SquareType } from '../utils/helpers';
+import { areSameCell, SquareType } from '../utils/helpers';
 import { MAX_HEIGHT, MAX_WIDTH } from './workspaceStore';
 
 type LayoutSlice = {
@@ -42,7 +42,8 @@ const createDraggedSlice: StateCreator<
   draggedItem: undefined,
   draggedPosition: undefined,
   setDraggedPosition: (i, j) => {
-    if (get().draggedPosition?.[0] !== i || get().draggedPosition?.[1] !== j) {
+    const draggedPosition = get().draggedPosition;
+    if (!draggedPosition || !areSameCell(draggedPosition, [i, j])) {
       set({ draggedPosition: [i, j] });
     }
   },

--- a/src/store/layoutStore.ts
+++ b/src/store/layoutStore.ts
@@ -1,3 +1,4 @@
+import type { CellOption } from '../types/project';
 import { DependencyList, useEffect, useRef } from 'react';
 import create, { StateCreator } from 'zustand';
 import { Layout } from '../components/layout/Layout';
@@ -11,15 +12,15 @@ type LayoutSlice = {
 
 type DraggedSlice = {
   draggedItem: SquareType | undefined;
-  draggedPosition: [number, number] | undefined;
+  draggedPosition: CellOption;
   setDraggedPosition: (i: number, j: number) => void;
   setDraggedItem: (item: SquareType) => void;
   handleDropInGrid: () => void;
 };
 
 type SelectedSlice = {
-  selectedCell: [number, number] | undefined;
-  setSelectedCell: (selectedCell: [number, number] | undefined) => void;
+  selectedCell: CellOption;
+  setSelectedCell: (selectedCell: CellOption) => void;
 };
 
 const createLayoutSlice: StateCreator<

--- a/src/types/project.d.ts
+++ b/src/types/project.d.ts
@@ -1,0 +1,2 @@
+export type Cell = [number, number];
+export type CellOption = Cell | undefined;

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -317,3 +317,6 @@ export class SquareType {
 
 export const areSameCell = (cell1: Cell, cell2: Cell) =>
   cell1[0] === cell2[0] && cell1[1] === cell2[1];
+
+export const isTouchDevice = () =>
+  'ontouchstart' in window || window.navigator.maxTouchPoints > 0;

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -1,3 +1,5 @@
+import type { Cell } from '../types/project';
+
 export enum GridMode {
   Draw,
   Plan,
@@ -312,3 +314,6 @@ export class SquareType {
     throw new URIError('Invalid SquareType string: ' + strRepr);
   }
 }
+
+export const areSameCell = (cell1: Cell, cell2: Cell) =>
+  cell1[0] === cell2[0] && cell1[1] === cell2[1];


### PR DESCRIPTION
Here's a first attempt at adding mobile support by allowing users to move items with 2 taps.

Tap to select and then tap again on the same item to unselect or tap somewhere else to move the item. Moving with taps also unselects the item as it seemed counterintuitive to have to unselect it after moving.

If no one finds any bugs with this, I think this basic implementation is a good start for now and we can improve it later.

Known opportunities for improvement (but may not be blockers to moving forward with this PR):
- Multi-touch events and gestures may cause unexpected behaviors. Can be avoided by not starting gestures on the grid.
- Tap outside the grid to deselect or other QOL ideas might be nice.

Other notes:
- I created a Cell type to represent `[number, number]` and put it in `src/types/project.d.ts`. Let me know if there's a better place.
- I created a helper function called `areSameCell` to compare cells. It could be used in a lot of the places where we're currently doing things like `clickedCell[0] !== selectedCell[0] || clickedCell[1] !== selectedCell[1]` as `!areSameCell(selectedCell, clickedCell)` to simplify and clarify.
    